### PR TITLE
fix: 引用が潜在的に危険な問題を修正

### DIFF
--- a/data/timestamp.go
+++ b/data/timestamp.go
@@ -80,5 +80,9 @@ func (t *Timestamp) UnmarshalJSON(data []byte) error {
 // a string in RFC3339Nano format.
 func (t Timestamp) String() string {
 	s, _ := ToString(t)
+	_, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return ""
+	}
 	return `"` + s + `"`
 }


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
このプルリクエストでは、タイムスタンプの文字列表現に関する問題を修正します。具体的には、RFC3339Nano形式の文字列としてタイムスタンプをパースする際のエラーハンドリングを追加し、パースに失敗した場合は空の文字列を返すように変更しています。

___
## PR Main Files Walkthrough:
`data/timestamp.go`: タイムスタンプの文字列表現を返すStringメソッドにエラーハンドリングを追加しました。具体的には、タイムスタンプをRFC3339Nano形式の文字列にパースする際にエラーが発生した場合、空の文字列を返すように変更しています。
