### PR TITLE
fix: クオーティングの潜在的な安全性問題を修正

### DIFF
--- a/data/timestamp.go
+++ b/data/timestamp.go
@@ -80,5 +80,9 @@ func (t *Timestamp) UnmarshalJSON(data []byte) error {
 // a string in RFC3339Nano format.
 func (t Timestamp) String() string {
 	s, _ := ToString(t)
+	_, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return ""
+	}
 	return `"` + s + `"`
 }


### PR DESCRIPTION
## Type
Bug fix

___
## Description
このプルリクエストでは、タイムスタンプの文字列表現における潜在的な安全性問題を修正します。具体的には、RFC3339Nano形式の文字列としてタイムスタンプを解析し、エラーが発生した場合は空の文字列を返すように変更されています。

___
## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>timestamp.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        data/timestamp.go<br><br>
        <strong><br>`String`関数にエラーハンドリングを追加しました。タイムスタンプをRFC3339Nano形式の文字列に変換し、その解析が失敗した場合は空の文字列を返すようになりました。</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/k-nhr/sensorbee/pull/13/files#diff-c3dd8e792926ae87087a10b220a2d64d83a7298df33fac3be782f254986640e0"> +4/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>