### PR TITLE
Fix potentially unsafe quoting

### DIFF
--- a/data/timestamp.go
+++ b/data/timestamp.go
@@ -80,5 +80,9 @@ func (t *Timestamp) UnmarshalJSON(data []byte) error {
 // a string in RFC3339Nano format.
 func (t Timestamp) String() string {
 	s, _ := ToString(t)
+	_, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return ""
+	}
 	return `"` + s + `"`
 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added error handling for time parsing in the `String` method of the `Timestamp` struct.
- The method now returns an empty string if the time parsing fails, ensuring safer quoting.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>timestamp.go</strong><dd><code>Add error handling for time parsing in `String` method</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

data/timestamp.go
<li>Added error handling for time parsing in <code>String</code> method.<br> <li> Return an empty string if time parsing fails.<br>


</details>
    

  </td>
  <td><a href="https://github.com/k-nhr/sensorbee/pull/30/files#diff-c3dd8e792926ae87087a10b220a2d64d83a7298df33fac3be782f254986640e0">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

